### PR TITLE
Better license template, readme fixes & improvements, misc

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-patreon: serpentiem

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,8 @@
-DMC3Crimson - zlib License  
+DMC3Crimson is licensed as follows:
+
+"""
+zlib License  
+
 Copyright (c) 2025 Berthrage
 
 This software is provided 'as-is', without any express or implied warranty.
@@ -22,119 +26,142 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
 SOFTWARE.
+"""
 
+The DMC3Crimson license applies to all parts of DMC3Crimson that are not
+externally maintained libraries.
 
-zlib License
+External libraries used by DMC3Crimson:
 
-Copyright (c) 2019-2021 serpentiem
+- DDMK, located at pointer_to_directory_or_file_placeholder, is licensed as follows:
 
-This software is provided 'as-is', without any express or implied
-warranty.  In no event will the authors be held liable for any damages
-arising from the use of this software.
+   """
+   zlib License
 
-Permission is granted to anyone to use this software for any purpose,
-including commercial applications, and to alter it and redistribute it
-freely, subject to the following restrictions:
+   Copyright (c) 2019-2021 serpentiem
 
-1. The origin of this software must not be misrepresented; you must not
-   claim that you wrote the original software. If you use this software
-   in a product, an acknowledgment in the product documentation would be
-   appreciated but is not required.
-2. Altered source versions must be plainly marked as such, and must not be
-   misrepresented as being the original software.
-3. This notice may not be removed or altered from any source distribution.
+   This software is provided 'as-is', without any express or implied
+   warranty.  In no event will the authors be held liable for any damages
+   arising from the use of this software.
 
-MIT License
+   Permission is granted to anyone to use this software for any purpose,
+   including commercial applications, and to alter it and redistribute it
+   freely, subject to the following restrictions:
 
-Copyright (c) 2022 Lyall
+   1. The origin of this software must not be misrepresented; you must not
+      claim that you wrote the original software. If you use this software
+      in a product, an acknowledgment in the product documentation would be
+      appreciated but is not required.
+   2. Altered source versions must be plainly marked as such, and must not be
+      misrepresented as being the original software.
+   3. This notice may not be removed or altered from any source distribution.
+   """
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+- DMCHDFix, located at pointer_to_directory_or_file_placeholder, is licensed as follows:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   """
+   MIT License
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+   Copyright (c) 2022 Lyall
 
- SDL 2.0 and newer are available under the zlib license :
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
 
-This software is provided 'as-is', without any express or implied
-warranty.  In no event will the authors be held liable for any damages
-arising from the use of this software.
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
 
-Permission is granted to anyone to use this software for any purpose,
-including commercial applications, and to alter it and redistribute it
-freely, subject to the following restrictions:
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+   """
 
-1. The origin of this software must not be misrepresented; you must not
-   claim that you wrote the original software. If you use this software
-   in a product, an acknowledgment in the product documentation would be
-   appreciated but is not required.
-2. Altered source versions must be plainly marked as such, and must not be
-   misrepresented as being the original software.
-3. This notice may not be removed or altered from any source distribution.
+- SDL2, located at pointer_to_directory_or_file_placeholder, is licensed as follows:
 
-================================================================================
-OpenGL Mathematics (GLM)
---------------------------------------------------------------------------------
-GLM is licensed under The Happy Bunny License or MIT License
+   """
+    SDL 2.0 and newer are available under the zlib license :
 
-================================================================================
-The Happy Bunny License (Modified MIT License)
---------------------------------------------------------------------------------
-Copyright (c) 2005 - G-Truc Creation
+   This software is provided 'as-is', without any express or implied
+   warranty.  In no event will the authors be held liable for any damages
+   arising from the use of this software.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   Permission is granted to anyone to use this software for any purpose,
+   including commercial applications, and to alter it and redistribute it
+   freely, subject to the following restrictions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+   1. The origin of this software must not be misrepresented; you must not
+      claim that you wrote the original software. If you use this software
+      in a product, an acknowledgment in the product documentation would be
+      appreciated but is not required.
+   2. Altered source versions must be plainly marked as such, and must not be
+      misrepresented as being the original software.
+   3. This notice may not be removed or altered from any source distribution.
+   """
 
-Restrictions:
- By making use of the Software for military purposes, you choose to make a
- Bunny unhappy.
+- GLM, located at pointer_to_directory_or_file_placeholder, is licensed as follows:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+   """
+   ================================================================================
+   OpenGL Mathematics (GLM)
+   --------------------------------------------------------------------------------
+   GLM is licensed under The Happy Bunny License or MIT License
 
-================================================================================
-The MIT License
---------------------------------------------------------------------------------
-Copyright (c) 2005 - G-Truc Creation
+   ================================================================================
+   The Happy Bunny License (Modified MIT License)
+   --------------------------------------------------------------------------------
+   Copyright (c) 2005 - G-Truc Creation
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+   Restrictions:
+   By making use of the Software for military purposes, you choose to make a
+   Bunny unhappy.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+   ================================================================================
+   The MIT License
+   --------------------------------------------------------------------------------
+   Copyright (c) 2005 - G-Truc Creation
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+   """
+
+rest of \ThirdParty\* to be added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="Public/fulllogo-with-fullcredits.png" alt="Logo" style="width: 2400px;"/>  
+![banner](Public/fulllogo-with-fullcredits.png)
 
 ## PATCH NOTES BETA LAUNCH BUILD 0.3
 Coming soon.
@@ -8,21 +8,21 @@ BACKUP your save files! Crimson has extensive save syncing built-in and things s
 
 ## CREDITS
 # C•Team  
-• Berthrage - Project Director, Lead Programmer, Artist, Reverse Engineering  
-• Siyan - Reverse Engineering, Gameplay Programmer, Q&A, Testing  
-• deepdarkkapustka - Reverse Engineering, Tooling, General Programmer  
-• Darkness - Backend, Devops, General Programmer, Reverse Engineering  
-• Charlie - Community Manager, Tester, Q&A  
-• The Hitchhiker - General Programmer, Reverse Engineering 
+- [Berthrage](https://github.com/berthrage) - Project Director, Lead Programmer, Artist, Reverse Engineering
+- [Siyan](https://github.com/SSSiyan) - Reverse Engineering, Gameplay Programmer, Q&A, Testing
+- [deepdarkkapustka](https://github.com/muhopensores) - Reverse Engineering, Tooling, General Programmer
+- [Darkness](https://github.com/amir-120) - Backend, Devops, General Programmer, Reverse Engineering
+- Charlie - Community Manager, Tester, Q&A
+- [The Hitchhiker](https://github.com/hitchhikingthrough) - General Programmer, Reverse Engineering 
 
 ## Contributions by
-• Cynuma - Artist  
-• Omar Nabelse - 3D Artist  
-• Che - Mod Tooling  
-• Vainiuss1 - Artist  
+- Cynuma - Artist
+- Omar Nabelse - 3D Artist
+- Che - Mod Tooling
+- Vainiuss1 - Artist
 
 # DDMK
-• serpentiem - Original DDMK's Developer  
+- [serpentiem](https://github.com/serpentiem) - [Original DDMK](https://github.com/serpentiem/ddmk)'s Developer
 
 # DMC3 Crimson is a free, open-source and non-commercial project
 C•Team is an independent development group and is not affiliated with, endorsed by, or sponsored by CAPCOM Co., Ltd. All trademarks, including Devil May Cry, are the property of their respective owners. This project is a non-commercial initiative made out of passion and respect for the original work.  
@@ -30,5 +30,4 @@ C•Team is an independent development group and is not affiliated with, endorse
 Warning: Be careful about downloading supposed Crimson builds from unofficial sources, they could be fake and/or contain malicious code.
 
 ## LICENSE
-DMC3 Crimson is licensed under the [zlib license](https://github.com/berthrage/Devil-May-Cry-3-Crimson/blob/main/LICENSE) and includes [DMCHDFix by Lyall](https://github.com/Lyall/DMCHDFix) packaged in. The rest of the licenses should be contained [here](https://github.com/serpentiem/ddmk/tree/master/ThirdParty).
-
+DMC3 Crimson is licensed under the [zlib license](https://github.com/berthrage/Devil-May-Cry-3-Crimson/blob/main/LICENSE) and includes [DMCHDFix by Lyall](https://github.com/Lyall/DMCHDFix) packaged in. The rest of the licenses should be contained [here](https://github.com/berthrage/Devil-May-Cry-3-Crimson/tree/master/ThirdParty).

--- a/src/dinput8.cpp
+++ b/src/dinput8.cpp
@@ -202,7 +202,11 @@ void Load() {
             "dmc2.exe",
             "Lucia.dll",
         },
-        {"dmc3.exe", "Crimson.dll", "SDL2.dll", "SDL2_mixer.dll"},
+        {
+            "dmc3.exe",
+            "Crimson.dll",
+            "SDL2.dll",
+            "SDL2_mixer.dll"},
         {
             "dmc4.exe",
             "Kyrie.dll",


### PR DESCRIPTION
Hey guys, nice to see that DMC3 modding is continuing.
However, there seems to be some problems about licensing side of the project. From my experience merging licenses in a file is generally not done / done in a specific way.

Main issues:
- It's unclear as to what's licensed with what. You should point to the directory or the file when you're adding it into your `LICENSE` file, [like done in nodejs](https://raw.githubusercontent.com/nodejs/node/refs/heads/main/LICENSE). I've modified the file to be compliant in this format, you can modify the placeholders & add the rest of the dependencies.
- I don't think it's necessary to include DDMK license since you're somewhat forking it? The credit done in readme and other parts should be fine. I may be wrong, I'm not entirely accustomed to DDMK nor your project.

Also, are you getting builds via the file `VS2022x64.bat`?
If so,
```
2: git submodule init
3: git submodule update
```
what are these lines for? Are you planning on moving libraries on [`ThirdParty`](https://github.com/berthrage/Devil-May-Cry-3-Crimson/tree/main/ThirdParty) to submodules? Currently there doesn't seem to be any submodules in the repository.

Btw, the installer has a duplicated file extension `crimsoninstall-0.3-windows-x64-x86.exe.exe`

Cheers!