### PR TITLE
Deactivate multiplayer camera if there is only one player alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <img src="Public/fulllogo-with-fullcredits.png" alt="Logo" style="width: 2400px;"/>  
 
+## PATCH NOTES BETA LAUNCH BUILD 0.3
+Coming soon.
+
 ## WARNING  
 BACKUP your save files! Crimson has extensive save syncing built-in and things should work just fine. But we will NOT be held responsible for loss of save game data.  
 

--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ C•Team is an independent development group and is not affiliated with, endorse
 
 Warning: Be careful about downloading supposed Crimson builds from unofficial sources, they could be fake and/or contain malicious code.
 
+## LICENSE
+DMC3 Crimson is licensed under the [zlib license](https://github.com/berthrage/Devil-May-Cry-3-Crimson/blob/main/LICENSE). The rest of the licenses should be contained [here](https://github.com/serpentiem/ddmk/tree/master/ThirdParty).
+

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ C•Team is an independent development group and is not affiliated with, endorse
 Warning: Be careful about downloading supposed Crimson builds from unofficial sources, they could be fake and/or contain malicious code.
 
 ## LICENSE
-DMC3 Crimson is licensed under the [zlib license](https://github.com/berthrage/Devil-May-Cry-3-Crimson/blob/main/LICENSE). The rest of the licenses should be contained [here](https://github.com/serpentiem/ddmk/tree/master/ThirdParty).
+DMC3 Crimson is licensed under the [zlib license](https://github.com/berthrage/Devil-May-Cry-3-Crimson/blob/main/LICENSE) and includes [DMCHDFix by Lyall](https://github.com/Lyall/DMCHDFix) packaged in. The rest of the licenses should be contained [here](https://github.com/serpentiem/ddmk/tree/master/ThirdParty).
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ BACKUP your save files! Crimson has extensive save syncing built-in and things s
 • deepdarkkapustka - Reverse Engineering, Tooling, General Programmer  
 • Darkness - Backend, Devops, General Programmer, Reverse Engineering  
 • Charlie - Community Manager, Tester, Q&A  
+• The Hitchhiker - General Programmer, Reverse Engineering 
 
 ## Contributions by
 • Cynuma - Artist  

--- a/src/CrimsonOnTick.cpp
+++ b/src/CrimsonOnTick.cpp
@@ -255,11 +255,13 @@ void MultiplayerCameraPositioningController() {
 	static float lerpFactor = lerpFactorOutTransition;
 	static std::chrono::time_point<std::chrono::steady_clock> transitionToMPStartTime;
 	static bool isTransitionTimerActive = false;
+	bool triggerMPCam = activeCrimsonConfig.Camera.multiplayerCamera? true : false;
 
 	int entityCount = 0; // Track valid entities for averaging
 	float playerWeight = 5.0f;  // Weight for playable characters
 	float enemyWeight = 1.0f;   // Weight for enemies
 	float totalWeight = 0.0f;
+	auto aliveCount = 0;
 
 	// Loop through player data
 	for (uint8 playerIndex = 0; playerIndex < activeConfig.Actor.playerCount; ++playerIndex) {
@@ -272,7 +274,9 @@ void MultiplayerCameraPositioningController() {
 		}
 		auto& actorData = *reinterpret_cast<PlayerActorData*>(newActorData.baseAddr);
 		auto& cloneActorData = *reinterpret_cast<PlayerActorData*>(actorData.cloneActorBaseAddr);
-
+		if (!actorData.dead) {
+			aliveCount++;
+		}
 		// Apply player weight to their position
 		g_customCameraPos[0] += actorData.position.x * playerWeight;
 		g_customCameraPos[1] += actorData.position.y * playerWeight;
@@ -289,7 +293,9 @@ void MultiplayerCameraPositioningController() {
 			entityCount++;
 		}
 	}
-
+	if (aliveCount<=1 && activeConfig.Actor.playerCount > 1) {
+		triggerMPCam = false;
+	}
 	// Loop through enemy data
 	for (auto enemy : enemyVectorData.metadata) {
 		if (!enemy.baseAddr) continue;
@@ -342,7 +348,6 @@ void MultiplayerCameraPositioningController() {
 
 	float cameraDistanceMP = (eventData.room >= ROOM::BLOODY_PALACE_1 && eventData.room <= ROOM::BLOODY_PALACE_10) || eventData.room? 2800.0f : 1900.0f;
 
-	bool triggerMPCam = activeCrimsonConfig.Camera.multiplayerCamera? true : false;
 	for (int i = 0; i < activeConfig.Actor.playerCount * 2; i++) {
 		float distanceTo1P = g_plEntityTo1PDistances[i];
 

--- a/src/CrimsonOnTick.cpp
+++ b/src/CrimsonOnTick.cpp
@@ -261,7 +261,7 @@ void MultiplayerCameraPositioningController() {
 	float playerWeight = 5.0f;  // Weight for playable characters
 	float enemyWeight = 1.0f;   // Weight for enemies
 	float totalWeight = 0.0f;
-	auto aliveCount = 0;
+	int alivePlayerCount = 0; // Track number of players still alive
 
 	// Loop through player data
 	for (uint8 playerIndex = 0; playerIndex < activeConfig.Actor.playerCount; ++playerIndex) {
@@ -275,7 +275,7 @@ void MultiplayerCameraPositioningController() {
 		auto& actorData = *reinterpret_cast<PlayerActorData*>(newActorData.baseAddr);
 		auto& cloneActorData = *reinterpret_cast<PlayerActorData*>(actorData.cloneActorBaseAddr);
 		if (!actorData.dead) {
-			aliveCount++;
+			alivePlayerCount++;
 		}
 		// Apply player weight to their position
 		g_customCameraPos[0] += actorData.position.x * playerWeight;
@@ -293,9 +293,12 @@ void MultiplayerCameraPositioningController() {
 			entityCount++;
 		}
 	}
-	if (aliveCount<=1 && activeConfig.Actor.playerCount > 1) {
+
+	// Turn off multiplayer camera when active player count is > 1 and only one player is alive
+	if (alivePlayerCount<=1 && activeConfig.Actor.playerCount > 1) {
 		triggerMPCam = false;
 	}
+
 	// Loop through enemy data
 	for (auto enemy : enemyVectorData.metadata) {
 		if (!enemy.baseAddr) continue;


### PR DESCRIPTION
This fixes an issue I mentioned in #167. 

The multiplayer camera tracks all players, regardless of whether they are dead or alive. 

My changes make it so that the multiplayer camera is deactivated when:
- The active player count is more than 1
- And the number of alive players is <=1 (the < might be redundant, but put it in just in case)