### PR TITLE
Remove inbuilt FPS cap and add proper detection of High Refresh Rate displays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,5 @@ link_directories(${CMAKE_PROJECT_NAME} PUBLIC ${CMAKE_BINARY_DIR}/lib)
 # Store the root folder
 set(PROJECT_ROOT ${CMAKE_CURRENT_LIST_DIR})
 
-set(DMC_INSTALL_DIR "C:/Program Files (x86)/Steam/steamapps/common/Devil May Cry HD Collection")
-
 add_subdirectory(ThirdParty)
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,5 +50,7 @@ link_directories(${CMAKE_PROJECT_NAME} PUBLIC ${CMAKE_BINARY_DIR}/lib)
 # Store the root folder
 set(PROJECT_ROOT ${CMAKE_CURRENT_LIST_DIR})
 
+set(DMC_INSTALL_DIR "C:/Program Files (x86)/Steam/steamapps/common/Devil May Cry HD Collection")
+
 add_subdirectory(ThirdParty)
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ set (ASM_FLAGS)
 
 set(CXX_LIBS
     d3d11.lib
+    dxgi.lib
     d3dcompiler.lib
     dinput8.lib
     #xinput.lib
@@ -262,6 +263,11 @@ target_compile_options(${PROJECT_NAME} PRIVATE
 
 set_target_properties(${PROJECT_NAME} PROPERTIES 
 OUTPUT_NAME Crimson)
+
+add_custom_command(TARGET Crimson POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Crimson> ${DMC_INSTALL_DIR}/Crimson.dll
+	COMMENT "Copying Crimson.dll"
+)
 
 project(dinput8_injector)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,8 +33,7 @@ set (ASM_LIBS)
 set (ASM_FLAGS)
 
 set(CXX_LIBS
-    d3d11.lib
-    dxgi.lib
+    d3d11.lib    
     d3dcompiler.lib
     dinput8.lib
     #xinput.lib
@@ -263,11 +262,6 @@ target_compile_options(${PROJECT_NAME} PRIVATE
 
 set_target_properties(${PROJECT_NAME} PROPERTIES 
 OUTPUT_NAME Crimson)
-
-add_custom_command(TARGET Crimson POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Crimson> ${DMC_INSTALL_DIR}/Crimson.dll
-	COMMENT "Copying Crimson.dll"
-)
 
 project(dinput8_injector)
 

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -250,6 +250,33 @@ void Toggle(bool enable) {
         *frameRateAddr = 60;
     }
 
+    // Remove framerate lock
+    {        
+        auto addr = (appBaseAddr + 0x2C5EB0);
+        auto jumpAddr = (appBaseAddr + 0x2C5F1D);
+		auto destAddr = (appBaseAddr + 0x2C5F29);
+        constexpr uint64 size = 2;
+        /*        
+		dmc3.exe+2C5F1D - 76 0A - jbe dmc3.exe+2C5F29
+        */
+
+        static Function func = {};
+
+        constexpr byte8 sect0[] = {
+			0xEB, 0x0A, // jmp dmc3.exe+2C5F29
+        };
+
+        if (!run) {
+            backupHelper.Save(jumpAddr, size);            
+        }
+
+        if (enable) {
+            WriteShortJump(jumpAddr, destAddr);
+        }
+        else {
+            backupHelper.Restore(jumpAddr);
+        }
+    }
 
     {
         auto addr             = (appBaseAddr + 0x2C5EB0);

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -96,7 +96,6 @@ namespace Hooks {
 void Init() {
     LogFunction();
 
-
     Install((appBaseAddr + 0x34F308), ::Base::Windows::RegisterClassExW, ::Hook::Windows::RegisterClassExW);
 #if 0 // TODO(): window message pump gets stuck... uhh investigate further?
 	Install


### PR DESCRIPTION
This PR implements proper Swapchain setup for exclusive fullscreen + High Refresh Rate display configs while removing the inbuilt 60 FPS lock (i.e. its only form of a framerate limiter).

**This breaks Crimson's Framerate limiter settings which dependes on the said routine.** Though conversely this should allow a custom limiter to be implemented (e.g. in the hooked `Present` calls). Please merge with caution.

Backgroud: I had some issues with the modded game's (high) refresh options - it always went to 60 FPS for me regardless of the config. With this patch this is fixed for me.